### PR TITLE
Update jquery.ui.touch-punch.js

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -61,6 +61,17 @@
 
     // Dispatch the simulated event to the target element
     event.target.dispatchEvent(simulatedEvent);
+    var target = event.target;
+
+    // Dispatch the simulated event to the target element
+    if (simulatedType === 'mousemove') {
+      // Special handling for mouse move: fire on element at the current location instead:
+      var elementAtPoint = document.elementFromPoint(event.clientX, event.clientY);
+      if (elementAtPoint !== null) {
+          target = elementAtPoint;
+      }
+    }
+    target.dispatchEvent(simulatedEvent);
   }
 
   /**


### PR DESCRIPTION
Mousemove event is expected to arrive on the node event is currently on, touch events are continuously sent on the node from which initial touch was made. Bridge the gaps to fix drag and drop issues on iPad when using libraries such as DynaTree.
